### PR TITLE
OJORISE-23-create-app-header

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,9 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import FloatingActionButton from "@/components/common/FloatingActionButton";
-import LoadingProgressCircle from "@/components/common/LoadingProgressCircle";
 import ProviderWrapper from "@/components/common/ProviderWrapper";
 import "react-toastify/dist/ReactToastify.css";
-import { ToastContainer } from "react-toastify";
-import LinearProgress from "@/components/common/LinearProgress";
-import HamburgerWithMenu from "@/components/common/HamburgerWithMenu";
+import ClientLayoutWrapper from "@/components/common/ClientLayoutWrapper";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,29 +25,14 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+
   return (
-    <>
       <html lang="en">
         <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
           <ProviderWrapper>
-            <HamburgerWithMenu />
-            <ToastContainer
-              position="top-right"
-              autoClose={3000}
-              closeOnClick
-              pauseOnFocusLoss
-              pauseOnHover
-              draggable
-              role="alert"
-              newestOnTop
-            />
-            {children}
-            <LinearProgress colorClassName="bg-[black]" />
-            <FloatingActionButton />
-            <LoadingProgressCircle />
+            <ClientLayoutWrapper>{children}</ClientLayoutWrapper>
           </ProviderWrapper>
         </body>
       </html>
-    </>
   );
 }

--- a/src/components/common/AppHeader.tsx
+++ b/src/components/common/AppHeader.tsx
@@ -8,6 +8,14 @@ type Props = {
     toggleMenu: () => void;
 }
 
+const menuItems = [
+    {label: "MENU1", href:"/"},
+    {label: "MENU2", href:"/"},
+    {label: "MENU3", href:"/"},
+    {label: "MENU4", href:"/"},
+    {label: "MENU5", href:"/"},
+]
+
 
 function AppHeader({isOpen, toggleMenu}: Props) {
     const [isScrolled, setIsScrolled] = useState(false);
@@ -22,8 +30,27 @@ function AppHeader({isOpen, toggleMenu}: Props) {
 
     return (
         <header className={`pl-[24px] pr-[16px] xl:pl-[48px] xl:pr-[40px] fixed bg-white w-full z-49 ${isScrolled? "shadow-md":""}`}>
-            <div className="max-w-[1660px] inner flex align-middle items-center flex-wrap mt-0 mb-0 mr-auto ml-auto h-[56px] xl:h-[80px] justify-between">
-                <HamburgerIcon isOpen={isOpen} toggleMenu={toggleMenu} />
+            <div className="max-w-[1480px] inner flex align-middle items-center flex-wrap mt-0 mb-0 mr-auto ml-auto h-[56px] xl:h-[80px] justify-between">
+                {/*logo*/}
+                <div className="text-lg font-bold">OjoRise</div>
+
+                {/*desktopMenu(xl)*/}
+                <nav className="hidden xl:flex space-x-6">
+                    {menuItems.map((item, index) => (
+                        <a
+                        key={item.label}
+                        href={item.href}
+                        className="text-base font-medium text-neutral-800 hover:text-gray-600 transition"
+                        >
+                            {item.label}
+                        </a>
+                    ))}
+                </nav>
+
+                {/*mobile(xl under)*/}
+                <div className="xl:hidden">
+                    <HamburgerIcon isOpen={isOpen} toggleMenu={toggleMenu} />
+                </div>
             </div>
         </header>
     );

--- a/src/components/common/AppHeader.tsx
+++ b/src/components/common/AppHeader.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { memo, useEffect, useState } from "react";
+import HamburgerIcon from "@/components/common/HamburgerIcon";
+
+type Props = {
+    isOpen: boolean;
+    toggleMenu: () => void;
+}
+
+
+function AppHeader({isOpen, toggleMenu}: Props) {
+    const [isScrolled, setIsScrolled] = useState(false);
+
+    useEffect(() => {
+        const handler = () => {
+            setIsScrolled(window.scrollY > 0);
+        };
+        window.addEventListener("scroll", handler);
+        return () => window.removeEventListener("scroll", handler);
+    }, []);
+
+    return (
+        <header className={`pl-[24px] pr-[16px] xl:pl-[48px] xl:pr-[40px] fixed bg-white w-full z-49 ${isScrolled? "shadow-md":""}`}>
+            <div className="max-w-[1660px] inner flex align-middle items-center flex-wrap mt-0 mb-0 mr-auto ml-auto h-[56px] xl:h-[80px] justify-between">
+                <HamburgerIcon isOpen={isOpen} toggleMenu={toggleMenu} />
+            </div>
+        </header>
+    );
+}
+
+export default memo(AppHeader);

--- a/src/components/common/ClientLayoutWrapper.tsx
+++ b/src/components/common/ClientLayoutWrapper.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import OffCanvas from "@/components/common/OffCanvas";
+import {Fragment, useState} from "react";
+import AppHeader from "@/components/common/AppHeader";
+import {ToastContainer} from "react-toastify";
+import LinearProgress from "@/components/common/LinearProgress";
+import FloatingActionButton from "@/components/common/FloatingActionButton";
+import LoadingProgressCircle from "@/components/common/LoadingProgressCircle";
+
+export default function ClientLayoutWrapper({children} : {children: React.ReactNode}) {
+    const [isOpen, setIsOpen] = useState(false);
+    const toggleMenu = () => setIsOpen(prev => !prev);
+
+    return (
+        <Fragment>
+            <AppHeader isOpen={isOpen} toggleMenu={toggleMenu} />
+            <OffCanvas isOpen={isOpen} onClose={toggleMenu} />
+            <ToastContainer position="top-right" autoClose={2000} newestOnTop />
+            {children}
+            <LinearProgress colorClassName="bg-[black]" />
+            <FloatingActionButton />
+            <LoadingProgressCircle />
+        </Fragment>
+    );
+}

--- a/src/components/common/OffCanvas.tsx
+++ b/src/components/common/OffCanvas.tsx
@@ -48,7 +48,7 @@ export default function OffCanvas({ isOpen, onClose }: Props) {
                                 initial={{ opacity: 0, y: 20 }}
                                 animate={{ opacity: 1, y: 0 }}
                                 transition={{ delay: index * 0.05 }}
-                                className="text-2xl font-bold text-neutral-800 hover:text-yellow-600 transition"
+                                className="text-2xl font-bold text-neutral-800 hover:text-gray-600 transition"
                             >
                                 {item.label}
                             </motion.a>

--- a/src/components/common/OffCanvas.tsx
+++ b/src/components/common/OffCanvas.tsx
@@ -36,7 +36,7 @@ export default function OffCanvas({ isOpen, onClose }: Props) {
                         duration: 0.6,
                         ease: [0.4, 0, 1, 1],
                     }}
-                    className="fixed inset-0 z-50 w-full h-full bg-white flex flex-col items-center justify-center"
+                    className="fixed top-[56px] xl:top-[80px] right-0 z-40 w-full h-[calc(100%-56px)] xl:h-[calc(100%-80px)] bg-white flex flex-col items-center justify-center"
                 >
                     {/* menu section */}
                     <nav className="flex flex-col gap-8 text-center">


### PR DESCRIPTION
## #️⃣연관된 이슈
웹 환경과 모바일 환경에서의 각기 다른 레이아웃의 헤더를 추가하였습니다.


## 📝작업 내용

- [x] 로고, 햄버거 아이콘 헤더 안에 상속

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/6e6929f1-479f-4292-a8e9-bd361e4c556c)
![image](https://github.com/user-attachments/assets/2b431c44-af8f-4502-a13e-8c36c0109bea)
