### PR TITLE
OJORISE-98-fix-footer-design

### DIFF
--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -2,15 +2,17 @@ import Link from "next/link";
 
 export default function Footer() {
   return (
-    <footer className="w-full bg-neutral-100 border-t border-neutral-200 py-6 mt-12">
+    <footer className="w-full bg-neutral-100 border-t border-neutral-200 py-12 mt-12">
       <div className="max-w-5xl mx-auto px-4 flex flex-col sm:flex-row items-center justify-between gap-4 text-neutral-600 text-sm">
         <div className="flex items-center gap-2 mb-2 sm:mb-0">
           <span className="font-bold hidden sm:inline">OjoRise</span>
         </div>
+        <div className="flex-1 text-center">
+          <span>@{new Date().getFullYear()} OjoRise. All rights reserved.</span>
+        </div>
         <div className="flex flex-col sm:flex-row gap-1 sm:gap-4 items-center text-xs sm:text-sm">
-          <span>© {new Date().getFullYear()} OjoRise. All rights reserved.</span>
           <Link href="https://www.lguplus.com/" className="hover:underline">LG U+</Link>
-          <Link href="/" className="hover:underline">Link Section</Link>
+          <Link href="https://github.com/OjoRise" className="hover:underline">GitHub</Link>
         </div>
       </div>
     </footer>

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import Link from "next/link";
 
 export default function Footer() {
@@ -6,12 +5,11 @@ export default function Footer() {
     <footer className="w-full bg-neutral-100 border-t border-neutral-200 py-6 mt-12">
       <div className="max-w-5xl mx-auto px-4 flex flex-col sm:flex-row items-center justify-between gap-4 text-neutral-600 text-sm">
         <div className="flex items-center gap-2 mb-2 sm:mb-0">
-          <Image src="/logo.svg" alt="Logo" width={90} height={34} className="h-auto w-[90px] sm:w-[110px]" />
           <span className="font-bold hidden sm:inline">OjoRise</span>
         </div>
         <div className="flex flex-col sm:flex-row gap-1 sm:gap-4 items-center text-xs sm:text-sm">
           <span>© {new Date().getFullYear()} OjoRise. All rights reserved.</span>
-          <Link href="/" className="hover:underline">Link Section</Link>
+          <Link href="https://www.lguplus.com/" className="hover:underline">LG U+</Link>
           <Link href="/" className="hover:underline">Link Section</Link>
         </div>
       </div>


### PR DESCRIPTION
## #️⃣연관된 이슈
Footer의 디자인을 수정하였습니다.

## 📝작업 내용

- [x] 기존에 있던 Yople로고 삭제
- [x] 카피라이트 및 깃허브, LGU+ 홈페이지 링크 연결
- [x] 푸터 높이 재설정 및 카피라이트 가운제 정렬

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/18a4e6d1-7e4f-49ef-9b55-f0f358ceef80)

## 💬리뷰 요구사항(선택)
추후 디자인 수정이 필요하다면 말씀해주시기 바랍니다.
